### PR TITLE
feat: add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add automated workflow to approve and merge Dependabot PRs
- Uses official `dependabot/fetch-metadata` action for security
- Integrates with repository's auto-merge settings
- Streamlines dependency update process

## How it works
1. Triggers only on Dependabot PRs (`github.actor == 'dependabot[bot]'`)
2. Automatically approves the PR
3. Enables auto-merge (requires passing CI checks)
4. Repository auto-merge settings handle the final merge

## Test Plan
- [x] Workflow file syntax is valid
- [x] Proper permissions configured (`contents: write`, `pull-requests: write`)
- [ ] Test with actual Dependabot PR (will happen automatically)

This should significantly reduce manual overhead for dependency updates while maintaining safety through required CI checks.