### PR TITLE
Skip deploy preview for dependabot PRs

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -44,7 +44,7 @@ jobs:
         command: pages deploy ./dist --project-name=vite-pwa-test
 
   deploy-preview:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     
     permissions:


### PR DESCRIPTION
## Summary
- Modified deploy-preview job to skip execution for dependabot PRs
- Added condition `github.actor != 'dependabot[bot]'` to the job's if statement

## Rationale
Dependabot PRs only update dependencies and are automatically merged via the existing auto-merge workflow. Preview deployments for these PRs provide no value since:
- They don't contain user-facing changes that need visual review
- They consume unnecessary CI/CD resources
- They create deployment noise without benefit

## Test plan
- [x] Verify workflow syntax is valid
- [ ] Test with next dependabot PR to ensure preview job is skipped
- [ ] Confirm regular PRs still trigger preview deployments