### PR TITLE
Update to Tailwind CSS v4 configuration

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,5 @@
 export default {
   plugins: {
     '@tailwindcss/postcss': {},
-    autoprefixer: {},
   },
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,1 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";


### PR DESCRIPTION
## Summary
- Modernized CSS imports to use Tailwind CSS v4 syntax
- Simplified PostCSS configuration by removing autoprefixer dependency

## Changes Made
1. **src/index.css**: Replaced traditional `@tailwind` directives with modern `@import "tailwindcss"` 
2. **postcss.config.js**: Removed autoprefixer plugin (handled automatically by Tailwind v4)

## Benefits
- **Cleaner imports**: Single import statement instead of three separate directives
- **Reduced dependencies**: Autoprefixer is no longer needed with Tailwind v4
- **Modern syntax**: Aligns with current Tailwind CSS v4 best practices
- **Simplified config**: Less configuration to maintain

## Test Plan
- [x] Verify styles continue to work correctly
- [x] Confirm build process runs without errors
- [x] Test development server starts properly
- [ ] Validate production build includes all necessary styles