### PR TITLE
Enhance production deployment status with both URLs

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -73,15 +73,22 @@ jobs:
       with:
         script: |
           const deployUrl = '${{ steps.deploy.outputs.deployment-url }}';
+          const productionUrl = 'https://${{ steps.project-name.outputs.name }}.pages.dev';
           const deploymentId = ${{ steps.deployment.outputs.result }};
+          
+          // Use production URL as the main environment URL for production deployments
+          const environmentUrl = productionUrl;
+          const description = deployUrl 
+            ? `Production deployment successful - Live: ${productionUrl} | Commit: ${deployUrl}`
+            : 'Production deployment failed';
           
           await github.rest.repos.createDeploymentStatus({
             owner: context.repo.owner,
             repo: context.repo.repo,
             deployment_id: deploymentId,
             state: deployUrl ? 'success' : 'failure',
-            environment_url: deployUrl,
-            description: deployUrl ? 'Production deployment successful' : 'Production deployment failed'
+            environment_url: environmentUrl,
+            description: description
           });
 
   deploy-preview:


### PR DESCRIPTION
## Summary
- Updated production deployment status to show both production URL and commit-specific URL
- Set `environment_url` to the main production URL for easier access
- Enhanced description to include both URLs for completeness

## Changes Made

### 🌐 Dual URL Display
- **Main environment URL**: `https://vite-pwa-test.pages.dev` (production site)
- **Description includes both**:
  - Production URL: `https://vite-pwa-test.pages.dev` 
  - Commit-specific URL: `https://abc123.vite-pwa-test.pages.dev`

### 📝 Enhanced Status Messages
**Success format:**
```
Production deployment successful - Live: https://vite-pwa-test.pages.dev | Commit: https://abc123.vite-pwa-test.pages.dev
```

**Failure format:**
```
Production deployment failed
```

## Benefits
- **Quick access**: Click deployment status → goes to main production site
- **Full visibility**: Description shows both URLs for debugging/verification
- **Consistency**: Matches preview deployment pattern but prioritizes production URL
- **User-friendly**: Main site is more useful than commit-specific URL for production

## Test Plan
- [x] Verify workflow syntax is valid
- [ ] Test production deployment shows correct URLs
- [ ] Confirm environment_url links to main production site
- [ ] Validate description format includes both URLs